### PR TITLE
Added partial_cmp

### DIFF
--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -694,6 +694,28 @@ pub trait IndexedParallelIterator: ExactParallelIterator {
                     })
     }
 
+    /// Lexicographically compares the elements of this `ParallelIterator` with those of
+    /// another.
+    fn partial_cmp<I>(self, other: I) -> Option<Ordering>
+        where I: IntoParallelIterator<Item = Self::Item>,
+              I::Iter: IndexedParallelIterator,
+              Self::Item: PartialOrd
+    {
+        self.zip(other.into_par_iter())
+            .map(|(x, y)| PartialOrd::partial_cmp(&x, &y))
+            .reduce(|| Some(Ordering::Equal),
+                    |cmp_a, cmp_b| match (cmp_a, cmp_b) {
+                        (Some(a), Some(b)) => {
+                            if a != Ordering::Equal {
+                                Some(b)
+                            } else {
+                                Some(a)
+                            }
+                        }
+                        _ => None,
+                    })
+    }
+
     /// Yields an index along with each item.
     fn enumerate(self) -> Enumerate<Self> {
         Enumerate::new(self)


### PR DESCRIPTION
Uses the existing zip, map, and reduce combinators to implement partial_cmp.