### PR TITLE
Fixed cmp and Associated Tests

### DIFF
--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -687,7 +687,7 @@ pub trait IndexedParallelIterator: ExactParallelIterator {
         self.zip(other.into_par_iter())
             .map(|(x, y)| Ord::cmp(&x, &y))
             .reduce(|| Ordering::Equal,
-                    |cmp_a, cmp_b| if cmp_a != Ordering::Equal {
+                    |cmp_a, cmp_b| if cmp_a == Ordering::Equal {
                         cmp_b
                     } else {
                         cmp_a

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -272,33 +272,48 @@ pub fn check_range_exact_and_bounded() {
 }
 
 #[test]
-pub fn check_cmp() {
-    let a: Vec<usize> = (0..1024).collect();
-    let b: Vec<usize> = (0..1024).collect();
+pub fn check_cmp_direct() {
+    let a = (0..1024).into_par_iter();
+    let b = (0..1024).into_par_iter();
 
-    let result = a.cmp(&b);
+    let result = a.cmp(b);
 
     assert!(result == ::std::cmp::Ordering::Equal);
 }
 
 #[test]
-pub fn check_cmp_lt() {
-    let a: Vec<usize> = (0..1024).collect();
-    let b: Vec<usize> = (1..1024).collect();
+pub fn check_cmp_to_seq() {
+    assert_eq!((0..1024).into_par_iter().cmp(0..1024), (0..1024).cmp(0..1024));
+}
 
-    let result = a.cmp(&b);
+#[test]
+pub fn check_cmp_lt_direct() {
+    let a = (0..1024).into_par_iter();
+    let b = (1..1024).into_par_iter();
+
+    let result = a.cmp(b);
 
     assert!(result == ::std::cmp::Ordering::Less);
 }
 
 #[test]
-pub fn check_cmp_gt() {
-    let a: Vec<usize> = (1..1024).collect();
-    let b: Vec<usize> = (0..1024).collect();
+pub fn check_cmp_lt_to_seq() {
+    assert_eq!((0..1024).into_par_iter().cmp(1..1024), (0..1024).cmp(1..1024))
+}
 
-    let result = a.cmp(&b);
+#[test]
+pub fn check_cmp_gt_direct() {
+    let a = (1..1024).into_par_iter();
+    let b = (0..1024).into_par_iter();
+
+    let result = a.cmp(b);
 
     assert!(result == ::std::cmp::Ordering::Greater);
+}
+
+#[test]
+pub fn check_cmp_gt_to_seq() {
+    assert_eq!((1..1024).into_par_iter().cmp(0..1024), (1..1024).cmp(0..1024))
 }
 
 #[test]


### PR DESCRIPTION
cmp had an inversed if statement that neeeded to be rectified.

Tests were modified to actually use to par_iter cmp both directly between two par_iters
and between a par_iter and a sequential